### PR TITLE
detecting test env and setting config file accordingly

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,12 +1,16 @@
 import os
-
-from flask import Flask, render_template
+import sys
+from flask import Flask
 
 from . import mongoengine as db
 
 
-PROJECT_PATH = os.path.abspath(os.path.dirname(__file__) + '/..')
-os.environ.setdefault('SETTINGS', PROJECT_PATH + '/settings.py')
+settings_file = 'settings.py'
+if 'unittest' in sys.argv[0]:
+    settings_file = 'settings.test.py'
+
+PROJECT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+os.environ.setdefault('SETTINGS', os.path.join(PROJECT_PATH, settings_file))
 
 app = Flask('neomad')
 app.config.from_envvar('SETTINGS')

--- a/settings.test.py
+++ b/settings.test.py
@@ -6,7 +6,7 @@ PORT = 5000
 
 # MongoDB connection settings
 DATABASE = {
-  'db': 'neomad',
+  'db': 'neomad_test',
   'username': 'root',
   'host': 'localhost',  # set this value to 'db' if using docker-compose server.
   'password': '',


### PR DESCRIPTION
This uses 'settings.test.py' when running tests, with a different db name.